### PR TITLE
add slash at end of config dir

### DIFF
--- a/Plex-Meta-Manager.xml
+++ b/Plex-Meta-Manager.xml
@@ -40,7 +40,7 @@ Unraid Setup Guide: https://metamanager.wiki/en/latest/home/guides/unraid.html</
   <DonateText>Support the PMM Developer!</DonateText>
   <DonateLink>https://github.com/sponsors/meisnate12</DonateLink>
   <Requires/>
-  <Config Name="Config Directory" Target="/config" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/Plex-Meta-Manager/</Config>
+  <Config Name="Config Directory" Target="/config/" Default="" Mode="rw" Description="" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/Plex-Meta-Manager/</Config>
   <Config Name="Configuration File (--config)" Target="PMM_CONFIG" Default="" Mode="" Description="Specify the location of the configuration YAML file." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Run Immediately (--run)" Target="PMM_RUN" Default="" Mode="" Description="Set as 'true' to perform a run immediately, bypassing the time to run flag." Type="Variable" Display="advanced" Required="false" Mask="false"/>
   <Config Name="Time to Run (--time)" Target="PMM_TIME" Default="" Mode="" Description="Specify the times of day that Plex Meta Manager will run with comma-separated list of times in HH:MM format." Type="Variable" Display="advanced" Required="false" Mask="false"/>


### PR DESCRIPTION
Apparently `/config` should be `/config/` according to https://github.com/meisnate12/Plex-Meta-Manager/issues/9